### PR TITLE
Add simple VAT calculator for macOS

### DIFF
--- a/vat_calculator/README.md
+++ b/vat_calculator/README.md
@@ -1,0 +1,33 @@
+# Kalkulator VAT dla macOS
+
+Ten prosty kalkulator VAT został napisany w Pythonie przy użyciu biblioteki `tkinter`. 
+
+## Uruchomienie
+1. Upewnij się, że masz zainstalowanego Pythona 3 oraz tkinter (standardowo jest dostępny w instalacji systemowej Pythona na macOS).
+2. W katalogu `vat_calculator` uruchom skrypt:
+   ```bash
+   python3 vat_calculator.py
+   ```
+
+## Funkcje
+- Obsługa polskich stawek VAT: 23%, 8% i 5%.
+- Możliwość przeliczania kwoty netto na brutto oraz brutto na netto.
+
+Po uruchomieniu aplikacji wprowadź kwotę, wybierz stawkę VAT oraz tryb obliczeń, a następnie kliknij "Oblicz".
+
+Możesz zbudować aplikację w formie pliku wykonywalnego na macOS za pomocą narzędzia `pyinstaller`:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile vat_calculator.py
+```
+
+W katalogu `dist` pojawi się program, który można uruchomić jak typową aplikację w terminalu.
+
+## Testy
+
+Aby uruchomić testy jednostkowe napisane w `pytest`, wykonaj polecenie:
+
+```bash
+python3 -m pytest
+```

--- a/vat_calculator/logic.py
+++ b/vat_calculator/logic.py
@@ -1,0 +1,14 @@
+VAT_RATES = [23, 8, 5]
+
+
+def netto_to_brutto(netto: float, rate: float) -> tuple[float, float]:
+    """Return (gross, vat_amount) for given netto and VAT rate."""
+    vat_amount = netto * rate / 100
+    return netto + vat_amount, vat_amount
+
+
+def brutto_to_netto(gross: float, rate: float) -> tuple[float, float]:
+    """Return (netto, vat_amount) for given gross and VAT rate."""
+    netto = gross / (1 + rate / 100)
+    vat_amount = gross - netto
+    return netto, vat_amount

--- a/vat_calculator/tests/test_logic.py
+++ b/vat_calculator/tests/test_logic.py
@@ -1,0 +1,23 @@
+import pytest
+
+from vat_calculator.logic import netto_to_brutto, brutto_to_netto
+
+
+def test_netto_to_brutto():
+    gross, vat = netto_to_brutto(100, 23)
+    assert gross == pytest.approx(123)
+    assert vat == pytest.approx(23)
+
+
+def test_brutto_to_netto():
+    net, vat = brutto_to_netto(123, 23)
+    assert net == pytest.approx(100)
+    assert vat == pytest.approx(23)
+
+
+def test_round_trip():
+    for rate in [23, 8, 5]:
+        gross, vat1 = netto_to_brutto(200, rate)
+        net, vat2 = brutto_to_netto(gross, rate)
+        assert net == pytest.approx(200)
+        assert vat1 == pytest.approx(vat2)

--- a/vat_calculator/vat_calculator.py
+++ b/vat_calculator/vat_calculator.py
@@ -1,0 +1,73 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from .logic import brutto_to_netto, netto_to_brutto, VAT_RATES
+
+def calculate():
+    try:
+        price_text = entry_price.get().replace(',', '.')
+        price = float(price_text)
+    except ValueError:
+        messagebox.showerror("B\u0142\u0105d", "Niepoprawna kwota")
+        return
+
+    rate = float(rate_var.get())
+
+    if calc_type.get() == 'netto':
+        gross, vat_amount = netto_to_brutto(price, rate)
+        result_var.set(
+            f"Kwota VAT: {vat_amount:.2f} z\u0142\nCena brutto: {gross:.2f} z\u0142"
+        )
+    else:
+        net, vat_amount = brutto_to_netto(price, rate)
+        result_var.set(
+            f"Kwota VAT: {vat_amount:.2f} z\u0142\nCena netto: {net:.2f} z\u0142"
+        )
+
+
+def main():
+    global root, entry_price, rate_var, calc_type, result_var
+
+    root = tk.Tk()
+    root.title("Kalkulator VAT")
+
+    mainframe = ttk.Frame(root, padding="10")
+    mainframe.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+
+    # Price entry
+    entry_price = ttk.Entry(mainframe, width=15)
+    entry_price.grid(row=0, column=1, padx=5, pady=5)
+    ttk.Label(mainframe, text="Kwota").grid(row=0, column=0, sticky=tk.W)
+
+    # VAT rate dropdown
+    rate_var = tk.StringVar(value=str(VAT_RATES[0]))
+    rate_menu = ttk.OptionMenu(
+        mainframe, rate_var, str(VAT_RATES[0]), *map(str, VAT_RATES)
+    )
+    rate_menu.grid(row=1, column=1, padx=5, pady=5)
+    ttk.Label(mainframe, text="Stawka VAT (%)").grid(row=1, column=0, sticky=tk.W)
+
+    # Calculation type radio buttons
+    calc_type = tk.StringVar(value='netto')
+    radio_netto = ttk.Radiobutton(
+        mainframe, text='Netto \u2192 Brutto', variable=calc_type, value='netto'
+    )
+    radio_brutto = ttk.Radiobutton(
+        mainframe, text='Brutto \u2192 Netto', variable=calc_type, value='brutto'
+    )
+    radio_netto.grid(row=2, column=0, sticky=tk.W)
+    radio_brutto.grid(row=2, column=1, sticky=tk.W)
+
+    # Calculate button
+    calculate_btn = ttk.Button(mainframe, text="Oblicz", command=calculate)
+    calculate_btn.grid(row=3, column=0, columnspan=2, pady=10)
+
+    result_var = tk.StringVar()
+    result_label = ttk.Label(mainframe, textvariable=result_var, justify='left')
+    result_label.grid(row=4, column=0, columnspan=2)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python Tkinter VAT calculator with Polish tax rates
- document how to run it on macOS
- add basic pytest test suite

## Testing
- `python3 -m py_compile vat_calculator/*.py`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa5b6ebf483328fcc472d3d6aa48f